### PR TITLE
Update command to handle both getting and setting

### DIFF
--- a/MapCycle.cs
+++ b/MapCycle.cs
@@ -83,8 +83,6 @@ public class MapCycle : BasePlugin, IPluginConfig<ConfigGen>
         // Set the next map on map start
         RegisterListener<Listeners.OnMapStart>(SetNextMap);
 
-        AddCommand("mc_nextmap?", "Get the next map of the cycle", OnGetNextMapCommand);
-
         if (hotReload){
             if (!Config.RtvEnabled)
             {
@@ -139,11 +137,13 @@ public class MapCycle : BasePlugin, IPluginConfig<ConfigGen>
         });
     }
 
-    [ConsoleCommand("mc_nextmap", "Set the next map of the cycle")]
-    [RequiresPermissions("@css/changemap")]
-    [CommandHelper(minArgs: 1, usage: "<#map name>", whoCanExecute: CommandUsage.CLIENT_AND_SERVER)]
+    [ConsoleCommand("mc_nextmap", "Gets/sets the next map of the cycle")]
     public void OnSetNextCommand(CCSPlayerController? caller, CommandInfo info)
     {
+        if(info.ArgCount == 1 || !AdminManager.PlayerHasPermissions(caller, "@css/changemap")) {
+            OnGetNextMapCommand(caller, info);
+            return;
+        }
         var commandMapName = info.GetArg(1);
         var map = Config.Maps.FirstOrDefault(x => x.Name == commandMapName);
         if (map == null)

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,8 @@ I dedicate a significant part of my free time to coding and developing meaningfu
 
 ## Commands
 ### Map Cycle
-- **`mc_nextmap?` / `mc_nextmap de_dust2` (SERVER CONSOLE)**: Use `mc_nextmap?` to check the upcoming map. To set the next map, input `mc_nextmap de_dust2`.
-- **`!mc_nextmap?` / `!mc_nextmap de_dust2` (CHAT)**: Enter `!mc_nextmap?` to view the next map. To select a different map, type `!mc_nextmap de_dust2`.
+- **`mc_nextmap` / `mc_nextmap de_dust2` (SERVER CONSOLE)**: Use `mc_nextmap` to check the upcoming map. To set the next map, input `mc_nextmap de_dust2`.
+- **`!mc_nextmap` / `!mc_nextmap de_dust2` (CHAT)**: Enter `!mc_nextmap` to view the next map. To select a different map, type `!mc_nextmap de_dust2`.
 - **`!mc_goto de_dust2`**: This command allows direct access to a chosen map (`de_dust2` in this case) in your cycle, bypassing the need to wait for the current match to end.
 - **`!mc_go`**: Use this command to immediately transition to the next map, without the need to wait for the current match to conclude.
 


### PR DESCRIPTION
This MR consolidates the `mc_nextmap` and `mc_nextmap?` command into one.

If the executor does not specify a map OR they do not have permission to change the map, the previous behavior of `mc_nextmap?` is run.

Otherwise, (since the executor has permissions and did indeed specify a map), the previous behavior of `mc_nextmap [map]` is run.

This simplifies commands and reduces the amount of commands that players/admins need to remember.